### PR TITLE
get_all_stub_files(): Python 2 fix

### DIFF
--- a/typeshed_client/finder.py
+++ b/typeshed_client/finder.py
@@ -29,6 +29,9 @@ class SearchContext(NamedTuple):
     search_path: Sequence[Path]
     version: PythonVersion
     platform: str
+        
+    def is_python2(self) -> bool:
+        return self.version[0] == 2
 
 
 def get_search_context(
@@ -126,7 +129,7 @@ def get_all_stub_files(
     # typeshed
     versions = get_typeshed_versions(search_context.typeshed)
     typeshed_dirs = [search_context.typeshed]
-    if search_context.version[0] == 2:
+    if search_context.is_python2():
         typeshed_dirs.insert(0, search_context.typeshed / "@python2")
 
     for typeshed_dir in typeshed_dirs:
@@ -142,7 +145,7 @@ def get_all_stub_files(
                 continue
             if version.max is not None and search_context.version > version.max:
                 continue
-            if typeshed_dir.name != "@python2" and version.in_python2:
+            if search_context.is_python2() and typeshed_dir.name != "@python2" and version.in_python2:
                 continue
             if entry.is_dir():
                 seen = yield from _get_all_stub_files_from_directory(

--- a/typeshed_client/finder.py
+++ b/typeshed_client/finder.py
@@ -29,7 +29,7 @@ class SearchContext(NamedTuple):
     search_path: Sequence[Path]
     version: PythonVersion
     platform: str
-        
+
     def is_python2(self) -> bool:
         return self.version[0] == 2
 
@@ -145,7 +145,11 @@ def get_all_stub_files(
                 continue
             if version.max is not None and search_context.version > version.max:
                 continue
-            if search_context.is_python2() and typeshed_dir.name != "@python2" and version.in_python2:
+            if (
+                search_context.is_python2()
+                and typeshed_dir.name != "@python2"
+                and version.in_python2
+            ):
                 continue
             if entry.is_dir():
                 seen = yield from _get_all_stub_files_from_directory(


### PR DESCRIPTION
In Python 3, it would skip all stubs that also exist in `@python2`.