### PR TITLE
Improve type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,37 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+strict_optional = true
+warn_no_return = true
+disallow_any_unimported = true
+
+# Across versions of mypy, the flags toggled by --strict vary.  To ensure
+# we have reproducible type check, we instead manually specify the flags
+warn_unused_configs = true
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+# warn_return_any = true
+warn_unreachable = true
+implicit_reexport = false
+strict_equality = true
+
+# Disallow any
+# disallow_any_explicit = true
+disallow_any_decorated = true
+
+exclude = [
+  "typeshed_client/typeshed",
+  "tests/typeshed",
+  "build/",
+  ".tox/",
+]

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ with (ts_client_dir / "__init__.py").open() as f:
 
 
 def find_bundled_files() -> Iterable[str]:
+    yield str(ts_client_dir / "py.typed")
     for root, _, files in os.walk(typeshed_dir):
         root_path = Path(root)
         for file in files:

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import ast
 import os
 from pathlib import Path
 import re
+from typing import Iterable
 from setuptools import setup
 
 
@@ -14,11 +15,14 @@ _version_re = re.compile(r"__version__\s+=\s+(?P<version>.*)")
 
 
 with (ts_client_dir / "__init__.py").open() as f:
-    version = _version_re.search(f.read()).group("version")
+    match = _version_re.search(f.read())
+    if match is None:
+        raise RuntimeError("Could not find in the init file")
+    version = match.group("version")
     version = str(ast.literal_eval(version))
 
 
-def find_bundled_files():
+def find_bundled_files() -> Iterable[str]:
     for root, _, files in os.walk(typeshed_dir):
         root_path = Path(root)
         for file in files:

--- a/tests/test.py
+++ b/tests/test.py
@@ -217,7 +217,7 @@ class TestParser(unittest.TestCase):
         info = get_stub_names("conditions", search_context=ctx)
         self.assertEqual(set(info.keys()), names | {"sys"})
 
-    def test_top_level_assert(self):
+    def test_top_level_assert(self) -> None:
         ctx = get_context((3, 6), "flat")
         info = get_stub_names("top_level_assert", search_context=ctx)
         self.assertEqual(set(info.keys()), set())
@@ -279,7 +279,7 @@ class IntegrationTest(unittest.TestCase):
 
     fake_path = typeshed_client.ModulePath(("some", "module"))
 
-    def test(self):
+    def test(self) -> None:
         ctx = get_search_context()
         for module_name, module_path in typeshed_client.get_all_stub_files(ctx):
             with self.subTest(path=module_name):

--- a/tests/test.py
+++ b/tests/test.py
@@ -72,6 +72,7 @@ class TestParser(unittest.TestCase):
     def test_get_stub_names(self) -> None:
         ctx = get_context((3, 5))
         names = get_stub_names("simple", search_context=ctx)
+        assert names is not None
         self.assertEqual(
             set(names.keys()),
             {
@@ -133,6 +134,7 @@ class TestParser(unittest.TestCase):
         # Classes
         self.check_nameinfo(names, "Cls", ast.ClassDef, has_child_nodes=True)
         cls_names = names["Cls"].child_nodes
+        assert cls_names is not None
         self.assertEqual(set(cls_names.keys()), {"attr", "method"})
         self.check_nameinfo(cls_names, "attr", ast.AnnAssign)
         self.check_nameinfo(cls_names, "method", ast.FunctionDef)
@@ -140,6 +142,7 @@ class TestParser(unittest.TestCase):
     def test_starimport(self) -> None:
         ctx = get_context((3, 5))
         names = get_stub_names("starimport", search_context=ctx)
+        assert names is not None
         self.assertEqual(set(names.keys()), {"public"})
         self.check_nameinfo(names, "public", typeshed_client.ImportedName)
         path = typeshed_client.ModulePath(("imported",))
@@ -157,6 +160,7 @@ class TestParser(unittest.TestCase):
         ):
             with self.subTest(mod):
                 names = get_stub_names(mod, search_context=ctx)
+                assert names is not None
                 self.assertEqual(set(names.keys()), {"f", "overloads"})
                 self.check_nameinfo(names, "f", typeshed_client.ImportedName)
                 path = typeshed_client.ModulePath(("subdir", "overloads"))
@@ -215,20 +219,25 @@ class TestParser(unittest.TestCase):
     ) -> None:
         ctx = get_context(version, platform)
         info = get_stub_names("conditions", search_context=ctx)
+        assert info is not None
         self.assertEqual(set(info.keys()), names | {"sys"})
 
     def test_top_level_assert(self) -> None:
         ctx = get_context((3, 6), "flat")
         info = get_stub_names("top_level_assert", search_context=ctx)
+        assert info is not None
         self.assertEqual(set(info.keys()), set())
         ctx = get_context((3, 6), "linux")
         info = get_stub_names("top_level_assert", search_context=ctx)
+        assert info is not None
         self.assertEqual(set(info.keys()), {"x", "sys"})
 
     def test_overloads(self) -> None:
         names = get_stub_names("overloads", search_context=get_context((3, 5)))
+        assert names is not None
         self.assertEqual(set(names.keys()), {"overload", "overloaded", "OverloadClass"})
         self.check_nameinfo(names, "overloaded", typeshed_client.OverloadedName)
+        assert isinstance(names["overloaded"].ast, typeshed_client.OverloadedName)
         definitions = names["overloaded"].ast.definitions
         self.assertEqual(len(definitions), 2)
         for defn in definitions:
@@ -237,6 +246,7 @@ class TestParser(unittest.TestCase):
         classdef = names["OverloadClass"]
         self.assertIsInstance(classdef.ast, ast.ClassDef)
         children = classdef.child_nodes
+        assert children is not None
         self.assertEqual(set(children.keys()), {"overloaded"})
         definitions = children["overloaded"].ast.definitions
         self.assertEqual(len(definitions), 2)
@@ -255,6 +265,7 @@ class TestResolver(unittest.TestCase):
 
         name_info = typeshed_client.NameInfo("exported", True, mock.ANY)
         resolved = res.get_name(path, "exported")
+        assert isinstance(resolved, typeshed_client.ImportedInfo)
         self.assertEqual(resolved, typeshed_client.ImportedInfo(other_path, name_info))
         self.assertIsInstance(resolved.info.ast, ast.AnnAssign)
 
@@ -284,6 +295,7 @@ class IntegrationTest(unittest.TestCase):
         for module_name, module_path in typeshed_client.get_all_stub_files(ctx):
             with self.subTest(path=module_name):
                 ast = typeshed_client.get_stub_ast(module_name, search_context=ctx)
+                assert ast is not None
                 typeshed_client.parser.parse_ast(ast, ctx, self.fake_path)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion=2.3.1
-envlist = py36,py37,py38,py39,py310,black
+envlist = py36,py37,py38,py39,py310,black,mypy
 isolated_build = True
 
 [testenv]
@@ -13,10 +13,17 @@ deps =
 commands =
     black --check .
 
+[testenv:mypy]
+deps =
+    mypy == 0.982
+    types-setuptools == 65.5.0.2
+commands =
+    mypy .
+
 [gh-actions]
 python =
     3.6: py36
     3.7: py37
     3.8: py38
-    3.9: py39, black
+    3.9: py39, black, mypy
     3.10: py310

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@ envlist = py36,py37,py38,py39,py310,black
 isolated_build = True
 
 [testenv]
-deps =
-    black == 22.3.0
 commands =
     python tests/test.py
 
 [testenv:black]
+deps =
+    black == 22.3.0
 commands =
     black --check .
 

--- a/typeshed_client/__init__.py
+++ b/typeshed_client/__init__.py
@@ -24,3 +24,22 @@ from .resolver import ImportedInfo, Resolver
 
 
 __version__ = "2.0.5"
+
+
+__all__ = [
+    "__version__",
+    "get_stub_ast",
+    "get_stub_file",
+    "get_all_stub_files",
+    "get_search_context",
+    "SearchContext",
+    "ModulePath",
+    "get_stub_names",
+    "parse_ast",
+    "ImportedName",
+    "NameDict",
+    "NameInfo",
+    "OverloadedName",
+    "ImportedInfo",
+    "Resolver",
+]

--- a/typeshed_client/parser.py
+++ b/typeshed_client/parser.py
@@ -277,14 +277,25 @@ class _LiteralEvalVisitor(ast.NodeVisitor):
     def __init__(self, ctx: SearchContext) -> None:
         self.ctx = ctx
 
-    def visit_Num(self, node: ast.Num) -> Union[int, float]:
-        return node.n
+    # from version 3.8 on all constants are represented as ast.Constant
+    if sys.version_info < (3, 8):
 
-    def visit_Str(self, node: ast.Str) -> str:
-        return node.s
+        def visit_Num(self, node: ast.Num) -> Union[int, float, complex]:
+            return node.n
 
-    def visit_Index(self, node: ast.Index) -> int:
-        return self.visit(node.value)
+        def visit_Str(self, node: ast.Str) -> str:
+            return node.s
+
+    else:
+
+        def visit_Constant(self, node: ast.Constant) -> Any:
+            return node.value
+
+    # from version 3.9 on an index is represented as the value directly
+    if sys.version_info < (3, 9):
+
+        def visit_Index(self, node: ast.Index) -> int:
+            return self.visit(node.value)
 
     def visit_Tuple(self, node: ast.Tuple) -> Tuple[Any, ...]:
         return tuple(self.visit(elt) for elt in node.elts)


### PR DESCRIPTION
I did some improvements regarding type checking. The main things include:

* Added [mypy](https://mypy.readthedocs.io/) to verify that the types are used correctly
* Fixed issues mypy detected
  * Note: in the tests I checked the types with `assert` because mypy does not yet support analysing assertIsNotNone and similar functions (see python/mypy/issues/5088 and the linked issue python/mypy/issues/4063)
* Explicitly re-export functions and types from the main package (see 94b572bb47d851d58bef1d3edb1cd7262ff9aae7)
* Most importantly: added a `py.typed` marker to denote that this library has type hints (see [PEP 561](https://peps.python.org/pep-0561/))

If you're not interested in some parts of this PR I can create a new one with only the parts you're interested in.