### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Projects for which ``typeshed_client`` could be useful include:
 Installation
 ------------
 
-``typeshed_client`` works on Python 3.6 and higher. To install it, run
+``typeshed_client`` works on Python 3.7 and higher. To install it, run
 ``python3 -m pip install typeshed_client``.
 
 Finding stubs
@@ -80,6 +80,10 @@ call ``resolver.get_fully_qualified_name('collections.Set')`` to retrieve the
 
 Changelog
 ---------
+
+Unreleased
+
+- Drop support for Python 3.6
 
 Version 2.1.0 (November 5, 2022)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target_version = ['py36', 'py37', 'py38', 'py39', 'py310', 'py311']
+target_version = ['py37', 'py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 skip-magic-trailing-comma = true
 preview = true

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -63,5 +62,5 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Topic :: Software Development",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion=2.3.1
-envlist = py36,py37,py38,py39,py310,py311,black,mypy
+envlist = py37,py38,py39,py310,py311,black,mypy
 isolated_build = True
 
 [testenv]
@@ -22,7 +22,6 @@ commands =
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
This should fix the CI failures in #69