### PR TITLE
Add support for try blocks in stubs

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -191,6 +191,15 @@ class TestParser(unittest.TestCase):
                     names["f"].ast, typeshed_client.ImportedName(path, "f")
                 )
 
+    def test_try(self) -> None:
+        ctx = get_context((3, 10))
+        names = get_stub_names("tryexcept", search_context=ctx)
+        assert names is not None
+        self.assertEqual(set(names), {"np", "f", "x"})
+        self.check_nameinfo(names, "np", typeshed_client.ImportedName)
+        self.check_nameinfo(names, "f", ast.FunctionDef)
+        self.check_nameinfo(names, "x", ast.AnnAssign)
+
     def check_nameinfo(
         self,
         names: typeshed_client.NameDict,

--- a/tests/typeshed/VERSIONS
+++ b/tests/typeshed/VERSIONS
@@ -17,3 +17,4 @@ about: 3.5-
 importabout: 3.5-
 tupleall: 3.5-
 starimportall: 3.5-
+tryexcept: 3.5-

--- a/tests/typeshed/tryexcept.pyi
+++ b/tests/typeshed/tryexcept.pyi
@@ -1,0 +1,9 @@
+try:
+    import numpy as np
+
+    def f(x: np.int64) -> np.int64: ...
+
+except ImportError:
+    pass
+finally:
+    x: int

--- a/typeshed_client/parser.py
+++ b/typeshed_client/parser.py
@@ -252,6 +252,14 @@ class _NameExtractor(ast.NodeVisitor):
             for stmt in node.orelse:
                 yield from self.visit(stmt)
 
+    def visit_Try(self, node: ast.Try) -> Iterable[NameInfo]:
+        # try-except sometimes gets used with conditional imports. We assume
+        # the try block is always executed.
+        for stmt in node.body:
+            yield from self.visit(stmt)
+        for stmt in node.finalbody:
+            yield from self.visit(stmt)
+
     def visit_Assert(self, node: ast.Assert) -> Iterable[NameInfo]:
         visitor = _LiteralEvalVisitor(self.ctx)
         value = visitor.visit(node.test)


### PR DESCRIPTION
On a local test I saw that kiwisolver/_cext.pyi and
rapidfuzz/process.pyi contain try blocks. Not standards-compliant
but I'd rather have typeshed-client not crash on this.
