### PR TITLE
Narrow AST parsing result type to `ast.Module` at all times

### DIFF
--- a/typeshed_client/finder.py
+++ b/typeshed_client/finder.py
@@ -105,7 +105,7 @@ def get_stub_file(
 
 def get_stub_ast(
     module_name: str, *, search_context: Optional[SearchContext] = None
-) -> Optional[ast.AST]:
+) -> Optional[ast.Module]:
     """Return the AST for the stub for the given module name."""
     path = get_stub_file(module_name, search_context=search_context)
     if path is None:
@@ -366,7 +366,7 @@ def find_typeshed() -> Path:
     return importlib_resources.files("typeshed_client") / "typeshed"
 
 
-def parse_stub_file(path: Path) -> ast.AST:
+def parse_stub_file(path: Path) -> ast.Module:
     text = path.read_text()
     return ast.parse(text, filename=str(path))
 


### PR DESCRIPTION
According to [this overload of `ast.parse`](https://github.com/python/typeshed/blob/7cae61f61a042a772010274dd1d8f1ee4454e5a4/stdlib/ast.pyi#L1798-L1806) for Python versions less than 3.13 and [this overload of `ast.parse`](https://github.com/python/typeshed/blob/7cae61f61a042a772010274dd1d8f1ee4454e5a4/stdlib/ast.pyi#L1719-L1728) for Python versions greater or equal to 3.13, `parse_stub_file` can only return `ast.Module` because the default value of the `mode` param in `ast.parse` is `"exec"` and `parse_stub_file` doesn't explicitly specify the argument for `mode`. Consequently, `get_stub_ast` can only return `ast.Module` or `None`.