### PR TITLE
Search in `.py` files for imports too

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,10 @@ call ``resolver.get_fully_qualified_name('collections.Set')`` to retrieve the
 Changelog
 ---------
 
+Unreleased
+
+- Search for names and imports in ``.py`` files in addition to ``.pyi`` files
+
 Version 2.7.0 (July 16, 2024)
 
 - Update bundled typeshed

--- a/tests/site-packages/usedotpy/__init__.py
+++ b/tests/site-packages/usedotpy/__init__.py
@@ -1,0 +1,1 @@
+from .stub import obj as obj

--- a/tests/site-packages/usedotpy/stub.pyi
+++ b/tests/site-packages/usedotpy/stub.pyi
@@ -1,0 +1,1 @@
+obj: float

--- a/tests/test.py
+++ b/tests/test.py
@@ -364,7 +364,6 @@ class IntegrationTest(unittest.TestCase):
     fake_path = typeshed_client.ModulePath(("some", "module"))
 
     def test(self) -> None:
-        return
         ctx = get_search_context(raise_on_warnings=True)
         for module_name, module_path in typeshed_client.get_all_stub_files(ctx):
             with self.subTest(name=module_name, path=module_path):

--- a/typeshed_client/finder.py
+++ b/typeshed_client/finder.py
@@ -117,7 +117,7 @@ def get_stub_ast(
     path = get_stub_file(module_name, search_context=search_context)
     if path is None:
         return None
-    return ast_parse_file(path)
+    return parse_stub_file(path)
 
 
 def get_all_stub_files(
@@ -373,7 +373,7 @@ def find_typeshed() -> Path:
     return importlib_resources.files("typeshed_client") / "typeshed"
 
 
-def ast_parse_file(path: Path) -> ast.Module:
+def parse_stub_file(path: Path) -> ast.Module:
     text = path.read_text()
     return ast.parse(text, filename=str(path))
 

--- a/typeshed_client/parser.py
+++ b/typeshed_client/parser.py
@@ -2,7 +2,6 @@
 
 import ast
 import logging
-from operator import is_
 import sys
 from typing import (
     Any,
@@ -17,8 +16,6 @@ from typing import (
     Type,
     Union,
 )
-
-from networkx import is_path
 
 from . import finder
 from .finder import ModulePath, SearchContext, get_search_context, parse_stub_file

--- a/typeshed_client/parser.py
+++ b/typeshed_client/parser.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 from . import finder
-from .finder import ModulePath, SearchContext, ast_parse_file, get_search_context
+from .finder import ModulePath, SearchContext, get_search_context, parse_stub_file
 
 log = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ def get_stub_names(
     if path is None:
         return None
     is_init = path.name == "__init__.pyi"
-    ast = ast_parse_file(path)
+    ast = parse_stub_file(path)
     return parse_ast(
         ast, search_context, ModulePath(tuple(module_name.split("."))), is_init=is_init
     )
@@ -448,7 +448,7 @@ def get_py_imported_name_sources(
     path = finder.get_py_module_file(module_name)
     if path is None:
         return {}, set()
-    ast = ast_parse_file(path)
+    ast = parse_stub_file(path)
     visitor = _PyImportedSourcesExtractor(module_name)
     visitor.visit(ast)
     return visitor.named_imports, visitor.star_imports

--- a/typeshed_client/resolver.py
+++ b/typeshed_client/resolver.py
@@ -15,10 +15,15 @@ ResolvedName = Union[None, ModulePath, ImportedInfo, parser.NameInfo]
 
 
 class Resolver:
-    def __init__(self, search_context: Optional[SearchContext] = None) -> None:
+    def __init__(
+        self,
+        search_context: Optional[SearchContext] = None,
+        search_py_files: bool = False,
+    ) -> None:
         if search_context is None:
             search_context = get_search_context()
         self.ctx = search_context
+        self.search_py_files = search_py_files
         self._module_cache: Dict[ModulePath, Module] = {}
 
     def get_module(self, module_name: ModulePath) -> "Module":
@@ -35,7 +40,7 @@ class Resolver:
     def get_name(self, module_name: ModulePath, name: str) -> ResolvedName:
         module = self.get_module(module_name)
         resolved_name = module.get_name(name, self)
-        if resolved_name is None:
+        if resolved_name is None and self.search_py_files:
             resolved_name = self._get_py_imported_name(module_name, name)
         return resolved_name
 

--- a/typeshed_client/resolver.py
+++ b/typeshed_client/resolver.py
@@ -18,12 +18,12 @@ class Resolver:
     def __init__(
         self,
         search_context: Optional[SearchContext] = None,
-        search_py_files: bool = False,
+        allow_py_files: bool = False,
     ) -> None:
         if search_context is None:
             search_context = get_search_context()
         self.ctx = search_context
-        self.search_py_files = search_py_files
+        self.allow_py_files = allow_py_files
         self._module_cache: Dict[ModulePath, Module] = {}
 
     def get_module(self, module_name: ModulePath) -> "Module":

--- a/typeshed_client/resolver.py
+++ b/typeshed_client/resolver.py
@@ -39,32 +39,7 @@ class Resolver:
 
     def get_name(self, module_name: ModulePath, name: str) -> ResolvedName:
         module = self.get_module(module_name)
-        resolved_name = module.get_name(name, self)
-        if resolved_name is None and self.search_py_files:
-            resolved_name = self._get_py_imported_name(module_name, name)
-        return resolved_name
-
-    def _get_py_imported_name(self, module_name: ModulePath, name: str) -> ResolvedName:
-        resolved_name = None
-        try:
-            named_imports, star_imports = parser.get_py_imported_name_sources(
-                module_name
-            )
-            for star_import in star_imports:
-                import_source = ModulePath(tuple(star_import.split(".")))
-                if import_source != module_name:
-                    # Try to resolve stub from star import
-                    resolved_name = self.get_name(import_source, name)
-                if resolved_name is not None:
-                    break
-            if resolved_name is None and name in named_imports:
-                import_source = ModulePath(tuple(named_imports[name].split(".")))
-                if import_source != module_name:
-                    # Try to resolve stub from named import
-                    resolved_name = self.get_name(import_source, name)
-        except Exception:
-            pass
-        return resolved_name
+        return module.get_name(name, self)
 
     def get_fully_qualified_name(self, name: str) -> ResolvedName:
         """Public API."""


### PR DESCRIPTION
Fixes #117. Closes #118.

Confirmed that this works for the original use case:

```
In [1]: import typeshed_client

In [2]: res = typeshed_client.Resolver()

In [3]: res.get_fully_qualified_name("torch.argmax")
Out[3]: ImportedInfo(source_module=('torch', '_C', '_VariableFunctions'), info=NameInfo(name='argmax', is_exported=True, ast=<ast.FunctionDef object at 0x103871210>, child_nodes=None))
```