### PR TITLE
Parser improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,8 @@ Changelog
 Unreleased
 
 - Search for names and imports in ``.py`` files in addition to ``.pyi`` files
+- Allow more redefinitions in stub files. ``OverloadedName`` objects can now
+  contain ``ImportedName`` objects.
 
 Version 2.7.0 (July 16, 2024)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -336,13 +336,25 @@ class TestResolver(unittest.TestCase):
 
 
 class IntegrationTest(unittest.TestCase):
-    """Tests that all files in typeshed are parsed without error."""
+    """Tests that all files in typeshed are parsed without error.
+
+    This runs on all stubs found in the current virtual environment, so this may
+    find failures not seen elsewhere if run in an environment with many installed
+    packages.
+
+    """
 
     fake_path = typeshed_client.ModulePath(("some", "module"))
+    invalid_modules = {
+        "pytype.tools.merge_pyi.test_data.typevar",
+        "pytype.tools.merge_pyi.test_data.imports",
+    }
 
     def test(self) -> None:
         ctx = get_search_context(raise_on_warnings=True)
         for module_name, module_path in typeshed_client.get_all_stub_files(ctx):
+            if module_name in self.invalid_modules:
+                continue
             with self.subTest(name=module_name, path=module_path):
                 try:
                     ast = typeshed_client.get_stub_ast(module_name, search_context=ctx)
@@ -353,7 +365,11 @@ class IntegrationTest(unittest.TestCase):
                 assert ast is not None
                 is_init = module_path.name == "__init__.pyi"
                 typeshed_client.parser.parse_ast(
-                    ast, ctx, ModulePath(tuple(module_name.split("."))), is_init=is_init
+                    ast,
+                    ctx,
+                    ModulePath(tuple(module_name.split("."))),
+                    is_init=is_init,
+                    file_path=module_path,
                 )
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,7 @@
 import ast
 import unittest
 from pathlib import Path
-from typing import Any, Optional, Set, Type
+from typing import Any, ClassVar, Optional, Set, Type
 from unittest import mock
 
 import typeshed_client
@@ -368,7 +368,7 @@ class IntegrationTest(unittest.TestCase):
     """
 
     fake_path = typeshed_client.ModulePath(("some", "module"))
-    invalid_modules = {
+    invalid_modules: ClassVar[Set[str]] = {
         "pytype.tools.merge_pyi.test_data.typevar",
         "pytype.tools.merge_pyi.test_data.imports",
     }

--- a/typeshed_client/parser.py
+++ b/typeshed_client/parser.py
@@ -2,8 +2,8 @@
 
 import ast
 import logging
-from pathlib import Path
 import sys
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -17,8 +17,6 @@ from typing import (
     Type,
     Union,
 )
-
-from isort import file
 
 from . import finder
 from .finder import ModulePath, SearchContext, get_search_context, parse_stub_file
@@ -84,7 +82,11 @@ def parse_ast(
     is_py_file: bool = False,
 ) -> NameDict:
     visitor = _NameExtractor(
-        search_context, module_name, is_init=is_init, file_path=file_path, is_py_file=is_py_file
+        search_context,
+        module_name,
+        is_init=is_init,
+        file_path=file_path,
+        is_py_file=is_py_file,
     )
     name_dict: NameDict = {}
     try:

--- a/typeshed_client/parser.py
+++ b/typeshed_client/parser.py
@@ -517,7 +517,7 @@ class _AssertFailed(Exception):
     """Raised when a top-level assert in a stub fails."""
 
 
-def _warn(message: str, ctx: SearchContext, file_path: Path | None) -> None:
+def _warn(message: str, ctx: SearchContext, file_path: Optional[Path]) -> None:
     if ctx.raise_on_warnings:
         raise InvalidStub(message, file_path)
     else:


### PR DESCRIPTION
- Make errors say what file they were in
- Allow more kinds of overloaded names (numpy has a name that is both
  imported and assigned to, for whatever reason)
- Ignore some files
