### PR TITLE
Make `_LiteralEvalVisitor` private again; expose a new `evaluate_expression_truthiness` function instead

### DIFF
--- a/typeshed_client/__init__.py
+++ b/typeshed_client/__init__.py
@@ -11,9 +11,11 @@ from .finder import (
 )
 from .parser import (
     ImportedName,
+    InvalidStub,
     NameDict,
     NameInfo,
     OverloadedName,
+    evaluate_expression_truthiness,
     get_stub_names,
     parse_ast,
 )
@@ -25,6 +27,7 @@ __version__ = "2.8.2"
 __all__ = [
     "ImportedInfo",
     "ImportedName",
+    "InvalidStub",
     "ModulePath",
     "NameDict",
     "NameInfo",
@@ -32,6 +35,7 @@ __all__ = [
     "Resolver",
     "SearchContext",
     "__version__",
+    "evaluate_expression_truthiness",
     "get_all_stub_files",
     "get_search_context",
     "get_stub_ast",

--- a/typeshed_client/__init__.py
+++ b/typeshed_client/__init__.py
@@ -11,7 +11,6 @@ from .finder import (
 )
 from .parser import (
     ImportedName,
-    LiteralEvalVisitor,
     NameDict,
     NameInfo,
     OverloadedName,
@@ -26,7 +25,6 @@ __version__ = "2.8.2"
 __all__ = [
     "ImportedInfo",
     "ImportedName",
-    "LiteralEvalVisitor",
     "ModulePath",
     "NameDict",
     "NameInfo",

--- a/typeshed_client/parser.py
+++ b/typeshed_client/parser.py
@@ -305,7 +305,7 @@ class _NameExtractor(ast.NodeVisitor):
                 yield from self.visit(stmt)
 
     def _visit_condition(self, expr: ast.expr) -> Optional[bool]:
-        visitor = LiteralEvalVisitor(self.ctx, self.file_path)
+        visitor = _LiteralEvalVisitor(self.ctx, self.file_path)
         try:
             value = visitor.visit(expr)
         except InvalidStub:
@@ -430,17 +430,7 @@ class _NameExtractor(ast.NodeVisitor):
         raise InvalidStub(f"Cannot handle node {ast.dump(node)}", self.file_path)
 
 
-class LiteralEvalVisitor(ast.NodeVisitor):
-    """Visitor to evaluate the truthiness of a ``test`` expression in an ``ast.Compare`` node.
-
-    ``LiteralEvalVisitor(ctx, path).visit(node)`` will return ``True`` if ``node`` is an
-    expression that can be statically determined to always be ``True``, ``False`` if it can
-    be statically determined to always be ``False``, and ``None`` if its truthiness cannot
-    be determined statically. For example, if passed an AST node representing the expression
-    ``sys.platform == "linux"``, it will return ``True`` if ``ctx.platform`` is equal to
-    ``"linux"``, otherwise ``False``.
-    """
-
+class _LiteralEvalVisitor(ast.NodeVisitor):
     def __init__(self, ctx: SearchContext, file_path: Optional[Path]) -> None:
         self.ctx = ctx
         self.file_path = file_path


### PR DESCRIPTION
Fixup from #129 (see discussion in https://github.com/JelleZijlstra/typeshed_client/pull/129#discussion_r2225834465)
