### PR TITLE
Support for Python 3.12+ ``type`` alias statements (PEP 695)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,10 @@ call ``resolver.get_fully_qualified_name('collections.Set')`` to retrieve the
 Changelog
 ---------
 
+Unreleased
+
+- Support for Python 3.12+ ``type`` alias statements
+
 Version 2.11.0 (May 1, 2026)
 
 - Update bundled typeshed

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,4 +1,5 @@
 import ast
+import sys
 import unittest
 from pathlib import Path
 from typing import Any, ClassVar, Optional
@@ -213,6 +214,18 @@ class TestParser(unittest.TestCase):
         self.check_nameinfo(names, "np", typeshed_client.ImportedName)
         self.check_nameinfo(names, "f", ast.FunctionDef)
         self.check_nameinfo(names, "x", ast.AnnAssign)
+
+    @unittest.skipUnless(
+        sys.version_info >= (3, 12), "PEP 695 `type` syntax requires Python 3.12+"
+    )
+    def test_type_alias(self) -> None:
+        ctx = get_context((3, 12))
+        names = get_stub_names("typealias", search_context=ctx)
+        assert names is not None
+        self.assertEqual(set(names), {"Alias", "Generic", "_Private"})
+        self.check_nameinfo(names, "Alias", ast.TypeAlias)
+        self.check_nameinfo(names, "Generic", ast.TypeAlias)
+        self.check_nameinfo(names, "_Private", ast.TypeAlias, is_exported=False)
 
     def check_nameinfo(
         self,

--- a/tests/typeshed/VERSIONS
+++ b/tests/typeshed/VERSIONS
@@ -18,3 +18,4 @@ importabout: 3.5-
 tupleall: 3.5-
 starimportall: 3.5-
 tryexcept: 3.5-
+typealias: 3.12-

--- a/tests/typeshed/typealias.pyi
+++ b/tests/typeshed/typealias.pyi
@@ -1,0 +1,3 @@
+type Alias = int
+type Generic[T] = list[T]
+type _Private = str

--- a/typeshed_client/parser.py
+++ b/typeshed_client/parser.py
@@ -2,6 +2,7 @@
 
 import ast
 import logging
+import sys
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Callable, NamedTuple, NoReturn, Optional, Union
@@ -284,6 +285,12 @@ class _NameExtractor(ast.NodeVisitor):
                 self.file_path,
             )
         yield NameInfo(target.id, _name_is_exported(target.id), node)
+
+    if sys.version_info >= (3, 12):
+
+        def visit_TypeAlias(self, node: ast.TypeAlias) -> Iterable[NameInfo]:
+            name = node.name.id
+            yield NameInfo(name, _name_is_exported(name), node)
 
     def visit_If(self, node: ast.If) -> Iterable[NameInfo]:
         value = self._visit_condition(node.test)


### PR DESCRIPTION
Closes #144