### PR TITLE
fix: remove license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         "Development Status :: 3 - Alpha",
         "Environment :: Console",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
> ********************************************************************************
> Please consider removing the following classifiers in favor of a SPDX license expression:
>
> License :: OSI Approved :: MIT License
>
> See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
> ********************************************************************************