### PR TITLE
Publish packages with attestations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,11 @@ jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI and TestPyPI
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/typeshed-client
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.13
@@ -32,5 +37,3 @@ jobs:
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
I think it would be nice if typeshed-client would start publishing packages with [attestations](https://docs.pypi.org/attestations/producing-attestations/).

In addition to this pull request, it would be needed to:

1. In https://github.com/JelleZijlstra/typeshed_client/settings/environments create an environment called `pypi` with default settings.
2. In https://pypi.org/manage/project/typeshed-client/settings/publishing/ configure GitHub publisher with owner `JelleZijlstra`, repository `typeshed_client`, workflow `publish.yml` and environment `pypi`.
3. [Not mandatory but recommended] In https://pypi.org/manage/project/typeshed-client/settings/ remove the `PYPI_API_TOKEN` so that it is no longer possible to publish packages with it.